### PR TITLE
Update postinst-monoaot

### DIFF
--- a/debian/postinst-monoaot
+++ b/debian/postinst-monoaot
@@ -8,7 +8,7 @@ then
 	if [ -e "/usr/lib/libmono-llvm.so.0" ]
 	then
 		TRYLLVM="try-llvm,"
-		LLVMNOTE=" (trying with LLVM, this might take a few minutes)"
+		LLVMNOTE=" (trying with LLVM, this might take a few hours)"
 	fi
 	if [ -z "$HASSSE41" ]
 	then


### PR DESCRIPTION
Updated the information of "trying with LLVM" to more accurately represent the possible precompile time on low-spec systems.

Ref:
- https://github.com/mono/mono/issues/11690
- https://github.com/mono/mono/issues/11776
- https://www.reddit.com/r/linuxquestions/comments/9mrfuc/attempting_to_install_monocomplete_freezes/
- https://www.raspberrypi.org/forums/viewtopic.php?t=226593
- https://stackoverflow.com/questions/53214618/failed-to-precompile-microsoft-codeanalysis-csharp-on-armbian-stretch
- https://gitter.im/travis-ci/travis-ci?at=5d28c844096dec3f019f4fd0
- https://twitter.com/xoofx/status/1049788429087776768