### PR TITLE
Bugfix: binfmt-detect-cli returns false negative for CLR with x64.

### DIFF
--- a/debian/detector/binfmt-detector-cli.c
+++ b/debian/detector/binfmt-detector-cli.c
@@ -80,7 +80,7 @@ int main(int argc, char **argv)
 		if (read < 1) exit(EXIT_FAILURE);
 		pe_magic = dotnet_header.pe.pe_magic[0]
 			 | dotnet_header.pe.pe_magic[1] << 8;
-		if (dotnet_header.pesig[0] != 'P' || dotnet_header.pesig[1] != 'E' || pe_magic != 0x10B) exit(EXIT_FAILURE);
+		if (dotnet_header.pesig[0] != 'P' || dotnet_header.pesig[1] != 'E' || (pe_magic != 0x10B && pe_magic != 0x20B)) exit(EXIT_FAILURE);
 		rva = dotnet_header.datadir.pe_cli_header.rva[0]
 		    | dotnet_header.datadir.pe_cli_header.rva[1] << 8
 		    | dotnet_header.datadir.pe_cli_header.rva[2] << 16


### PR DESCRIPTION
See: StackExchange / ask ubuntu / 2015-07-09: [binfmt-detector-cli from mono-runtime does not recognize x64 executables?](https://askubuntu.com/q/646475)

`binfmt-detect-cli` misses to check CLR with x64 and return EXIT_FAILURE.
As a result of my confirmation, CLR with x64 has pe_magic = 0x020B.
But currently, `binfmt-detect-cli.c` accepts pe_magic = 0x010B only.
So binfmt failed to execute CLR with x64 as below:

Sample code (hello.cs)
```csharp
using System;

public class Hello
{
 static void Main(string[] args)
  {
      Console.WriteLine("hello");
  }
}
```
compile
```
$ mono-csc /platform:x86 hello.cs -out:hello-x86.exe
$ mono-csc /platform:x64 hello.cs -out:hello-x64.exe
```
result
```
$ file hello-x86.exe hello-x64.exe 
hello-x86.exe: PE32 executable (console) Intel 80386 Mono/.Net assembly, for MS Windows
hello-x64.exe: PE32+ executable (console) x86-64 Mono/.Net assembly, for MS Windows
```
execute CLR with binfmt
```
$ ./hello-x86.exe
hello
```
```
$ ./hello-x64.exe
run-detectors: unable to find an interpreter for ./hello-x64.exe
```

This change is released under the MIT license.
Best regards.